### PR TITLE
Don't ignore files/directories starting with `.`

### DIFF
--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	ignore "github.com/sabhiram/go-gitignore"
@@ -97,10 +96,6 @@ func (f *Finder) Run() error {
 }
 
 func (f *Finder) isIgnorePath(path string) bool {
-	if path != "." && strings.HasPrefix(path, ".") {
-		return true
-	}
-
 	if _, found := ignoreDirectories[path]; found {
 		return true
 	}

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -15,8 +15,11 @@ type TestReplacer struct {
 }
 
 func (r *TestReplacer) Run(wg *sync.WaitGroup, path string) {
+	mu := &sync.Mutex{}
 	defer wg.Done()
+	mu.Lock()
 	r.Files = append(r.Files, path)
+	mu.Unlock()
 }
 
 func TestFinder_string(t *testing.T) {

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -60,13 +60,15 @@ func TestFinder_string(t *testing.T) {
 		t.Fatalf("Unexpected error happened %+v\n", err)
 	}
 
-	if len(r.Files) != 1 {
-		t.Fatalf("Exepectd files are one, but got %+v\n", r.Files)
+	if len(r.Files) != 2 {
+		t.Fatalf("Exepectd files are two, but got %+v\n", r.Files)
 	}
 
-	expected := "abc/dummy.log"
-	if r.Files[0] != expected {
-		t.Fatalf("Exepectd %+v, but got %+v\n", expected, r.Files[0])
+	expected := []string{"abc/dummy.log", ".gitignore"}
+	sort.Strings(expected)
+	sort.Strings(r.Files)
+	if !reflect.DeepEqual(r.Files, expected) {
+		t.Fatalf("Exepectd %+v, but got %+v\n", expected, r.Files)
 	}
 }
 
@@ -112,7 +114,7 @@ func TestFinder_appendedIgnoreFile(t *testing.T) {
 	}
 
 	if len(r.Files) != 2 {
-		t.Fatalf("Exepectd files are one, but got %+v\n", r.Files)
+		t.Fatalf("Exepectd files are two, but got %+v\n", r.Files)
 	}
 
 	expected := []string{"abc/dummy.log", "appended-ignore-file"}


### PR DESCRIPTION
Some setting files(e.g. `.github`) start with `.`.